### PR TITLE
Change reboot to shutdown in power menu

### DIFF
--- a/Tweak.xm
+++ b/Tweak.xm
@@ -410,7 +410,7 @@ UIAlertAction* powerOffButton = [UIAlertAction
 actionWithTitle:@"Power Off Device"
 style:UIAlertActionStyleDefault
 handler:^(UIAlertAction * action) {
-restart();
+powerOff();
 }];
 
 // Cancel Button


### PR DESCRIPTION
You set up the shutdown earlier in the code, then never used it. I am assuming that you meant to shutdown here instead of reboot. If not, removing the shutdown code would make your tweak smaller.